### PR TITLE
Error fixed and restored a property

### DIFF
--- a/dist/Spotify.d.ts
+++ b/dist/Spotify.d.ts
@@ -224,7 +224,7 @@ export declare class Spotify extends Plugin {
     } | {
         exception?: undefined;
     })>;
-    fetch(query: string, requester: any): any;
+    fetch(query: string, source: string, requester: any): any;
     fetchPlaylistTracks(spotifyPlaylist: SpotifyPlaylist): Promise<void>;
     buildUnresolved(track: any, requester: any): Promise<Track>;
     compareValue(value: boolean): boolean;

--- a/dist/Spotify.js
+++ b/dist/Spotify.js
@@ -79,7 +79,7 @@ class Spotify extends poru_1.Plugin {
         if (query.startsWith(SHORT_LINK_PATTERN))
             return this.decodeSpotifyShortLink({ query, source, requester });
         if (source === "spotify" && !this.check(query))
-            return this.fetch(query, requester);
+            return this.fetch(query, source, requester);
         const data = spotifyPattern.exec(query) ?? [];
         const id = data[2];
         switch (data[1]) {
@@ -98,7 +98,7 @@ class Spotify extends poru_1.Plugin {
             default: {
                 return this._resolve({
                     query,
-                    source: this.poru.options.defaultPlatform,
+                    source: source ?? this.poru.options.defaultPlatform,
                     requester: requester,
                 });
             }
@@ -160,12 +160,12 @@ class Spotify extends poru_1.Plugin {
             return this.buildResponse(e.body?.error.message === "invalid id" ? "NO_MATCHES" : "LOAD_FAILED", [], undefined, e.body?.error.message ?? e.message);
         }
     }
-    async fetch(query, requester) {
+    async fetch(query, source, requester) {
         try {
             if (this.check(query))
                 return this.resolve({
                     query,
-                    source: this.poru.options.defaultPlatform,
+                    source: source ?? this.poru.options.defaultPlatform,
                     requester,
                 });
             const data = await this.spotifyManager.send(`/search/?q="${query}"&type=artist,album,track&market=${this.options.searchMarket ?? "US"}`);

--- a/dist/spotifyManager.js
+++ b/dist/spotifyManager.js
@@ -8,7 +8,7 @@ class SpotifyManager {
     manager;
     constructor(data) {
         this.manager = [];
-        if (data.clients.length) {
+        if (data.clients?.length) {
             for (const client of data.clients)
                 this.manager?.push(new RestManager_1.RestManager(client));
             this.mode = 'multiple';


### PR DESCRIPTION
I've addressed an error in the spotifyManager.js file:

TypeError: Cannot read properties of undefined (reading 'length')

The issue has been fixed. I've also restored the source property at Spotify,js. Previously, when the plugin was in use, the resolve method only returned the defaultPlatform instead of both defaultPlatform and source.

And apologize for the last PR.